### PR TITLE
Change brick generation function

### DIFF
--- a/board_brick.go
+++ b/board_brick.go
@@ -161,9 +161,11 @@ func (board *Board) RemoveFullLines() int {
 
 func (board *Board) BrickNext() *Brick {
 	rand.Seed(time.Now().UTC().UnixNano())
-	brick := &Bricks[rand.Intn(7)]
-	brick.Position = Position{4, brick.StartOffset - 1}
-	brick.Anchored = false
+	newBrick := Bricks[rand.Intn(7)]
+	newBrick.Position = Position{4, newBrick.StartOffset - 1}
+	newBrick.Anchored = false
+
+	brick := &newBrick
 	board.Brick = brick
 	brick.Board = board
 


### PR DESCRIPTION
This commit introduce  new mechanism for brick generation. From now all
bricks are copies of the base layouts. Thank to this all new bricks
start with same rotation position.
